### PR TITLE
Change: Remove unneeded return statements

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,11 +18,10 @@ pub struct Config {
 }
 
 fn join_with_comma<T: ToString>(ips: &[T]) -> String {
-    return ips
-        .iter()
+    ips.iter()
         .map(|ip| ip.to_string())
         .collect::<Vec<String>>()
-        .join(", ");
+        .join(", ")
 }
 
 impl fmt::Display for Config {

--- a/src/nordvpn/server.rs
+++ b/src/nordvpn/server.rs
@@ -11,7 +11,7 @@ pub struct Server {
 
 impl Server {
     pub fn supports_ipv6(&self) -> bool {
-        return self.ip_addresses.iter().any(IpAddr::is_ipv6);
+        self.ip_addresses.iter().any(IpAddr::is_ipv6)
     }
 
     pub fn endpoint(&self) -> String {


### PR DESCRIPTION
This PR makes clippy happy by removing unneeded return statements.